### PR TITLE
Fix license in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "personnummer"
 description = "Validate Swedish personal identity numbers"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Simon Sawert <simon@sawert.se>"]
 edition = "2018"
-license-file = "LICENSE"
+license = "MIT"
 readme = "README.md"
 homepage = "https://personnummer.dev"
 repository = "https://github.com/personnummer/rust"


### PR DESCRIPTION
Fix license to use standard license, this requires a new release.