### PR TITLE
Make Personnummer::date public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ impl Error for PersonnummerError {}
 #[allow(dead_code)]
 /// Personnummer holds relevant data to check for valid personal identity numbers.
 pub struct Personnummer {
-    date: chrono::NaiveDate,
+    pub date: chrono::NaiveDate,
     serial: u32,
     control: u8,
     divider: char,


### PR DESCRIPTION
**Type of change**

- [X] New feature
- [ ] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Changes the visibility of `Personnummer::date` to `public`.

**Related issue**

None.

**Motivation**

Once you got a `Personnummer`, it is parsed and validated. Having access to the date enables to get more information about a person, such as year of birth etc. The [JS](https://github.com/personnummer/js) version has public properties for those details and I believe the [Python](https://github.com/personnummer/python) exposes the parts of the personnummer.

**Checklist**

- [ ] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
- [ ] Documentation of new public methods exists.
