### PR TITLE
Expose the parts of the personal identity number

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,26 @@ impl Personnummer {
     pub fn is_coordination_number(&self) -> bool {
         self.coordination
     }
+
+    /// Year of date of birth.
+    pub fn year(&self) -> i32 {
+        self.date.year()
+    }
+
+    /// Month of date of birth.
+    pub fn month(&self) -> u32 {
+        self.date.month()
+    }
+
+    /// Day of date of birth.
+    pub fn day(&self) -> u32 {
+        self.date.day()
+    }
+
+    /// Serial part of personal identity number.
+    pub fn serial(&self) -> u32 {
+        self.serial
+    }
 }
 
 /// Calculate the checksum based on luhn algorithm. See more information here:


### PR DESCRIPTION
**Type of change**

- [X] New feature
- [ ] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Exposes the parts of the personal identity number; date, month, day, serial.

**Related issue**

None

**Motivation**

Having an instance of `Personnummer` means the personal identity number is successfully parsed. Having access to the parts of the personal identity number opens up for more usage of the `Personnummer`.

Similar api are available in the JS and Python projects.

**Checklist**

- [ ] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
- [X] Documentation of new public methods exists.
