### PR TITLE
Disable default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ homepage = "https://personnummer.dev"
 repository = "https://github.com/personnummer/rust"
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "std",
+] }
 lazy_static = "1.4.0"
 regex = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,14 +182,12 @@ impl Personnummer {
     pub fn get_age(&self) -> i32 {
         let now = Utc::now();
 
-        if self.date.month() > now.month() {
+        if self.date.month() > now.month()
+            || self.date.month() == now.month() && self.date.day() > now.day()
+        {
             now.year() - self.date.year() - 1
         } else {
-            if self.date.month() == now.month() && self.date.day() > now.day() {
-                now.year() - self.date.year() - 1
-            } else {
-                now.year() - self.date.year()
-            }
+            now.year() - self.date.year()
         }
     }
 


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [ ] Bug fix
- [X] Security patch
- [ ] Documentation update

**Description**

Disable default features and enable only the features needed. This remove the dependency on time v0.1.44.

**Related issue**

<!-- Issue which this PR is connected to, if any. -->

**Motivation**
```sh
cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 458 security advisories (from /Users/markus/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (33 crate dependencies)
Crate:     time
Version:   0.1.44
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.44
└── chrono 0.4.22
    └── personnummer 3.1.0

error: 1 vulnerability found!
```

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [x] Style lints passes.
- [ ] Documentation of new public methods exists.
